### PR TITLE
FIX: upload to different artifact names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,4 +19,5 @@ runs:
       shell: bash
     - uses: actions/upload-artifact@v4
       with:
+        name: pip-constraints-${{ inputs.python-version }}
         path: .constraints/py${{ inputs.python-version }}.txt


### PR DESCRIPTION
Fixes a bug that was introduced in #14. See [`actions/upload-artifact` v4 migration guide](https://github.com/actions/upload-artifact/blob/v4.1.0/docs/MIGRATION.md\#multiple-uploads-to-the-same-named-artifact).