### PR TITLE
ENH: use `uv pip compile` if possible

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -31,7 +31,9 @@
     "codecov",
     "commitlint",
     "compwa",
+    "elif",
     "prereleased",
+    "pyproject",
     "redeboer",
     "venv"
   ],

--- a/action.yml
+++ b/action.yml
@@ -13,8 +13,30 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
-    - run: pip install git+https://github.com/ComPWA/update-pip-constraints@v1
+
+    - name: Determine package configuration file
+      run: |
+        if [ -f pyproject.toml ]; then
+          if grep -q "\[project\]" pyproject.toml; then
+            echo 'SETUP_FILE=pyproject.toml' | tee -a $GITHUB_ENV
+          fi
+        elif [ -f setup.cfg ]; then
+          if grep -q "\[metadata\]" setup.cfg && grep -q "\[options\]" setup.cfg; then
+            echo 'SETUP_FILE=setup.cfg' | tee -a $GITHUB_ENV
+          fi
+        fi
       shell: bash
+
+    - if: env.SETUP_FILE == 'setup.cfg'
+      run: |
+        pip install update-pip-constraints@git+https://github.com/ComPWA/update-pip-constraints@v1
+      shell: bash
+    - if: env.SETUP_FILE == 'pyproject.toml'
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        uv pip install --system update-pip-constraints@git+https://github.com/ComPWA/update-pip-constraints@v1
+      shell: bash
+
     - run: update-pip-constraints
       shell: bash
     - uses: actions/upload-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
-    - run: pip install git+https://github.com/ComPWA/update-pip-constraints@main
+    - run: pip install git+https://github.com/ComPWA/update-pip-constraints@v1
       shell: bash
     - run: update-pip-constraints
       shell: bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     importlib-metadata; python_version <"3.8.0"
     pip-tools >=6.2.0  # strip-extras and extras_require
     toml
-    uv; python_version >="3.7.0"
+    uv; python_version >="3.8.0"
 packages = find:
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     importlib-metadata; python_version <"3.8.0"
     pip-tools >=6.2.0  # strip-extras and extras_require
     toml
+    uv; python_version >="3.7.0"
 packages = find:
 package_dir =
     =src

--- a/src/update_pip_constraints/__init__.py
+++ b/src/update_pip_constraints/__init__.py
@@ -34,7 +34,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     python_version = args.python_version
     output_file = _form_constraint_file_path(python_version)
     excludes: List[str] = []
-    if sys.version_info < (3, 7) or not __uses_pyproject():
+    if sys.version_info < (3, 8) or not __uses_pyproject():
         excludes = [
             "pip",
             "setuptools",

--- a/src/update_pip_constraints/__init__.py
+++ b/src/update_pip_constraints/__init__.py
@@ -142,6 +142,7 @@ def update_constraints_file_py36(output_file: Path, unsafe_packages: List[str]) 
     else:
         from importlib.metadata import version  # noqa: PLC0415
 
+    print("Resolving dependencies with pip-tools...")  # noqa: T201
     output_file.parent.mkdir(exist_ok=True)
     command_arguments = [
         "-o",

--- a/src/update_pip_constraints/__init__.py
+++ b/src/update_pip_constraints/__init__.py
@@ -24,9 +24,10 @@ import toml
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = ArgumentParser(description="Update pip constraints file")
     parser.add_argument(
+        "-p",
         "--python-version",
         default=_get_python_version(),
-        help="Python version to use",
+        help="Python version to use. E.g. 3.9, 3.10, 3.11, etc.",
         type=str,
     )
     args = parser.parse_args(argv)

--- a/src/update_pip_constraints/__init__.py
+++ b/src/update_pip_constraints/__init__.py
@@ -8,10 +8,10 @@ See `Constraints Files
 # fmt: off
 import warnings  # noqa: I001
 warnings.filterwarnings("ignore", category=UserWarning)
-
 from setuptools import find_packages  # noqa: I001  # import setuptools first!
 # fmt: on
 
+import shutil
 import os
 import sys
 from configparser import ConfigParser
@@ -34,7 +34,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     python_version = args.python_version
     output_file = _form_constraint_file_path(python_version)
     excludes: List[str] = []
-    if sys.version_info < (3, 8) or not __uses_pyproject():
+    if shutil.which("uv") is None or not __uses_pyproject():
         excludes = [
             "pip",
             "setuptools",

--- a/tests/test_update_pip_constraints.py
+++ b/tests/test_update_pip_constraints.py
@@ -7,7 +7,7 @@ import pytest
 from update_pip_constraints import (
     _form_constraint_file_path,  # pyright: ignore[reportPrivateUsage]
     _get_python_version,  # pyright: ignore[reportPrivateUsage]
-    update_constraints_file,
+    update_constraints_file_py36,
 )
 
 
@@ -22,13 +22,13 @@ def test_get_python_version():
 
 
 @pytest.mark.slow()
-def test_update_constraints_file():
+def test_update_constraints_file_py36():
     if "CI" in os.environ:
         pytest.skip()
     this_directory = Path(__file__).parent.absolute()
     output_file = this_directory / "constraints.txt"
     with pytest.raises(SystemExit) as error:
-        update_constraints_file(output_file)
+        update_constraints_file_py36(output_file, unsafe_packages=[])
     assert error.type is SystemExit
     assert error.value.code == 0
     with open(output_file) as stream:


### PR DESCRIPTION
Test with:
```shell
pip install git+https://github.com/ComPWA/update-pip-constraints@uv
update-pip-constraints
```
or in the case of `uv`, use:
```shell
uv pip install update-pip-constraints@git+https://github.com/ComPWA/update-pip-constraints@uv
```

Optionally, if you have specific Pythons available on your system and are working with a package that is configured with `pyproject.toml`, you can directly create the `.constraints` file with:

```shell
update-pip-constraints -p 3.8
update-pip-constraints -p 3.9
...
```