### PR TITLE
ENH: print `pip compile` output with color

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         uv pip install --system update-pip-constraints@git+https://github.com/ComPWA/update-pip-constraints@v1
       shell: bash
 
-    - run: update-pip-constraints
+    - run: update-pip-constraints --color
       shell: bash
     - uses: actions/upload-artifact@v4
       with:

--- a/tests/test_update_pip_constraints.py
+++ b/tests/test_update_pip_constraints.py
@@ -28,7 +28,7 @@ def test_update_constraints_file_py36():
     this_directory = Path(__file__).parent.absolute()
     output_file = this_directory / "constraints.txt"
     with pytest.raises(SystemExit) as error:
-        update_constraints_file_py36(output_file, unsafe_packages=[])
+        update_constraints_file_py36(output_file, unsafe_packages=[], use_color=True)
     assert error.type is SystemExit
     assert error.value.code == 0
     with open(output_file) as stream:


### PR DESCRIPTION
Adds a `--color` flag to the `update-pip-constraints` CLI that enforces printing with color, whether with `pip-compile` and `uv pip compile` as backend. The action also prints with color now (compare [old output](https://github.com/redeboer/PawianTools/actions/runs/8189968529/job/22407326391#step:3:93) with [new output](https://github.com/redeboer/PawianTools/actions/runs/8247932953/job/22557159786#step:3:93)).