### PR TITLE
ENH: remove `--color=always` from requirements files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,8 +37,11 @@ runs:
         uv pip install --color=always --system update-pip-constraints@git+https://github.com/ComPWA/update-pip-constraints@v1
       shell: bash
 
-    - run: update-pip-constraints --color
+    - run: update-pip-constraints
       shell: bash
+      env:
+        FORCE_COLOR: "1"
+        TERM: ANSI
 
     - name: Show git diff
       run: git diff --color --unified=0

--- a/src/update_pip_constraints/__init__.py
+++ b/src/update_pip_constraints/__init__.py
@@ -24,12 +24,6 @@ import toml
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = ArgumentParser(description="Update pip constraints file")
     parser.add_argument(
-        "--color",
-        action="store_true",
-        default=False,
-        help="Force output to be colorized or not, instead of auto-detecting color support",
-    )
-    parser.add_argument(
         "-p",
         "--python-version",
         default=_get_python_version(),
@@ -46,12 +40,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             "setuptools",
             *_get_main_packages(),
         ]
-        exit_code = update_constraints_file_py36(output_file, excludes, args.color)
+        exit_code = update_constraints_file_py36(output_file, excludes)
     else:
         excludes = ["setuptools"]
-        exit_code = update_constraints_file(
-            output_file, python_version, excludes, args.color
-        )
+        exit_code = update_constraints_file(output_file, python_version, excludes)
     if exit_code != 0:
         msg = "There were issues running pip-compile"
         raise RuntimeError(msg)
@@ -116,7 +108,7 @@ def _form_constraint_file_path(python_version: str) -> Path:
 
 
 def update_constraints_file(
-    output_file: Path, python_version: str, unsafe_packages: List[str], use_color: bool
+    output_file: Path, python_version: str, unsafe_packages: List[str]
 ) -> int:
     import subprocess  # noqa: PLC0415, S404
 
@@ -124,7 +116,6 @@ def update_constraints_file(
         msg = "Package has to be configured with pyproject.toml"
         raise ValueError(msg)
     output_file.parent.mkdir(exist_ok=True)
-    color_args = ["--color=always"] if use_color else []
     command_arguments = [
         "uv",
         "pip",
@@ -133,7 +124,6 @@ def update_constraints_file(
         "-o",
         str(output_file),
         "--all-extras",
-        *color_args,
         "--no-annotate",
         f"--python-version={python_version}",
         "--upgrade",
@@ -144,9 +134,7 @@ def update_constraints_file(
     return subprocess.check_call(command_arguments)  # noqa: S603
 
 
-def update_constraints_file_py36(
-    output_file: Path, unsafe_packages: List[str], use_color: bool
-) -> int:
+def update_constraints_file_py36(output_file: Path, unsafe_packages: List[str]) -> int:
     from piptools.scripts import compile  # type: ignore[import]  # noqa: PLC0415
 
     if sys.version_info < (3, 8):
@@ -156,13 +144,11 @@ def update_constraints_file_py36(
 
     print("Resolving dependencies with pip-tools...")  # noqa: T201
     output_file.parent.mkdir(exist_ok=True)
-    color_args = ["--color"] if use_color else []
     command_arguments = [
         "-o",
         output_file,
         "--extra",
         "dev",
-        *color_args,
         "--no-annotate",
         "--strip-extras",
         "--upgrade",

--- a/tests/test_update_pip_constraints.py
+++ b/tests/test_update_pip_constraints.py
@@ -28,7 +28,7 @@ def test_update_constraints_file_py36():
     this_directory = Path(__file__).parent.absolute()
     output_file = this_directory / "constraints.txt"
     with pytest.raises(SystemExit) as error:
-        update_constraints_file_py36(output_file, unsafe_packages=[], use_color=True)
+        update_constraints_file_py36(output_file, unsafe_packages=[])
     assert error.type is SystemExit
     assert error.value.code == 0
     with open(output_file) as stream:


### PR DESCRIPTION
Partially reverts #23, the `--color` argument has been removed.